### PR TITLE
Fix migrations when drivers table already exists

### DIFF
--- a/database/migrations/2025_06_11_030743_create_drivers_table.php
+++ b/database/migrations/2025_06_11_030743_create_drivers_table.php
@@ -11,6 +11,10 @@ return new class extends Migration
      */
     public function up(): void
     {
+        if (Schema::hasTable('drivers')) {
+            return;
+        }
+
         Schema::create('drivers', function (Blueprint $table) {
             $table->id();
             $table->string('full_name');


### PR DESCRIPTION
## Summary
- check for existing `drivers` table before creating it

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848f5973cc483299c8dd50c66132935