### PR TITLE
Add driver details view and navigation

### DIFF
--- a/app/Http/Controllers/DriverController.php
+++ b/app/Http/Controllers/DriverController.php
@@ -66,7 +66,8 @@ class DriverController extends Controller
      */
     public function show(string $id)
     {
-        //
+        $driver = Driver::findOrFail($id);
+        return view('drivers.show', compact('driver'));
     }
 
     /**

--- a/resources/views/drivers/create.blade.php
+++ b/resources/views/drivers/create.blade.php
@@ -3,6 +3,7 @@
 @section('content')
 <div class="container">
     <h1>Add Driver</h1>
+    <a href="{{ route('drivers.index') }}" class="btn btn-secondary mb-3">Back</a>
     <form action="{{ route('drivers.store') }}" method="POST" enctype="multipart/form-data">
         @csrf
         <div class="mb-3">

--- a/resources/views/drivers/index.blade.php
+++ b/resources/views/drivers/index.blade.php
@@ -12,7 +12,7 @@
                 <th>Phone</th>
                 <th>Service</th>
                 <th>Approved</th>
-                <th></th>
+                <th>Actions</th>
             </tr>
         </thead>
         <tbody>
@@ -24,6 +24,7 @@
                 <td>{{ $driver->service_type }}</td>
                 <td>{{ $driver->approved ? 'Yes' : 'No' }}</td>
                 <td>
+                    <a href="{{ route('drivers.show', $driver) }}" class="btn btn-sm btn-info">More information</a>
                     @if(!$driver->approved)
                     <form action="{{ route('drivers.approve', $driver) }}" method="POST" style="display:inline;">
                         @csrf

--- a/resources/views/drivers/show.blade.php
+++ b/resources/views/drivers/show.blade.php
@@ -1,0 +1,66 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <h1>Driver Details</h1>
+    <a href="{{ route('drivers.index') }}" class="btn btn-secondary mb-3">Back</a>
+    <table class="table table-bordered">
+        <tr>
+            <th>ID</th>
+            <td>{{ $driver->id }}</td>
+        </tr>
+        <tr>
+            <th>Name</th>
+            <td>{{ $driver->full_name }}</td>
+        </tr>
+        <tr>
+            <th>Phone</th>
+            <td>{{ $driver->phone }}</td>
+        </tr>
+        <tr>
+            <th>Email</th>
+            <td>{{ $driver->email }}</td>
+        </tr>
+        <tr>
+            <th>Birthdate</th>
+            <td>{{ $driver->birthdate }}</td>
+        </tr>
+        <tr>
+            <th>Gender</th>
+            <td>{{ $driver->gender }}</td>
+        </tr>
+        <tr>
+            <th>Service</th>
+            <td>{{ $driver->service_type }}</td>
+        </tr>
+        <tr>
+            <th>Approved</th>
+            <td>{{ $driver->approved ? 'Yes' : 'No' }}</td>
+        </tr>
+        <tr>
+            <th>ID Card</th>
+            <td>{{ $driver->id_card_path }}</td>
+        </tr>
+        <tr>
+            <th>Driver License</th>
+            <td>{{ $driver->driver_license_path }}</td>
+        </tr>
+        <tr>
+            <th>Face Photo</th>
+            <td>{{ $driver->face_photo_path }}</td>
+        </tr>
+        <tr>
+            <th>Vehicle Registration</th>
+            <td>{{ $driver->vehicle_registration_path }}</td>
+        </tr>
+        <tr>
+            <th>Compulsory Insurance</th>
+            <td>{{ $driver->compulsory_insurance_path }}</td>
+        </tr>
+        <tr>
+            <th>Vehicle Insurance</th>
+            <td>{{ $driver->vehicle_insurance_path }}</td>
+        </tr>
+    </table>
+</div>
+@endsection


### PR DESCRIPTION
## Summary
- add back button on driver creation page
- show more information button in driver listing
- implement driver detail page
- display driver details in new view

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848f8418a6c832985ad4e77ca29b584