### PR TITLE
Enable admin file downloads from driver details

### DIFF
--- a/app/Http/Controllers/DriverController.php
+++ b/app/Http/Controllers/DriverController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\Driver;
+use Illuminate\Support\Facades\Storage;
 
 class DriverController extends Controller
 {
@@ -105,5 +106,29 @@ class DriverController extends Controller
         $driver->approved = true;
         $driver->save();
         return redirect()->route('drivers.index');
+    }
+
+    /**
+     * Download a specific driver document.
+     */
+    public function download(Driver $driver, string $field)
+    {
+        $allowed = [
+            'id_card',
+            'driver_license',
+            'face_photo',
+            'vehicle_registration',
+            'compulsory_insurance',
+            'vehicle_insurance',
+        ];
+
+        if (!in_array($field, $allowed)) {
+            abort(404);
+        }
+
+        $attribute = $field . '_path';
+        $path = $driver->{$attribute};
+
+        return Storage::disk('public')->download($path);
     }
 }

--- a/resources/views/drivers/show.blade.php
+++ b/resources/views/drivers/show.blade.php
@@ -39,27 +39,27 @@
         </tr>
         <tr>
             <th>ID Card</th>
-            <td>{{ $driver->id_card_path }}</td>
+            <td><a href="{{ route('drivers.download', [$driver, 'id_card']) }}">{{ basename($driver->id_card_path) }}</a></td>
         </tr>
         <tr>
             <th>Driver License</th>
-            <td>{{ $driver->driver_license_path }}</td>
+            <td><a href="{{ route('drivers.download', [$driver, 'driver_license']) }}">{{ basename($driver->driver_license_path) }}</a></td>
         </tr>
         <tr>
             <th>Face Photo</th>
-            <td>{{ $driver->face_photo_path }}</td>
+            <td><a href="{{ route('drivers.download', [$driver, 'face_photo']) }}">{{ basename($driver->face_photo_path) }}</a></td>
         </tr>
         <tr>
             <th>Vehicle Registration</th>
-            <td>{{ $driver->vehicle_registration_path }}</td>
+            <td><a href="{{ route('drivers.download', [$driver, 'vehicle_registration']) }}">{{ basename($driver->vehicle_registration_path) }}</a></td>
         </tr>
         <tr>
             <th>Compulsory Insurance</th>
-            <td>{{ $driver->compulsory_insurance_path }}</td>
+            <td><a href="{{ route('drivers.download', [$driver, 'compulsory_insurance']) }}">{{ basename($driver->compulsory_insurance_path) }}</a></td>
         </tr>
         <tr>
             <th>Vehicle Insurance</th>
-            <td>{{ $driver->vehicle_insurance_path }}</td>
+            <td><a href="{{ route('drivers.download', [$driver, 'vehicle_insurance']) }}">{{ basename($driver->vehicle_insurance_path) }}</a></td>
         </tr>
     </table>
 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,3 +8,4 @@ Route::get('/', function () {
 
 Route::resource('drivers', App\Http\Controllers\DriverController::class);
 Route::put('drivers/{driver}/approve', [App\Http\Controllers\DriverController::class, 'approve'])->name('drivers.approve');
+Route::get('drivers/{driver}/download/{field}', [App\Http\Controllers\DriverController::class, 'download'])->name('drivers.download');


### PR DESCRIPTION
## Summary
- add route for downloading driver documents
- implement download logic in `DriverController`
- link to downloads in driver detail view

## Testing
- `composer install` *(fails: missing PHP extensions)*

------
https://chatgpt.com/codex/tasks/task_e_6848ffd7c15c83298db93f43305bcadd