### PR TITLE
Add admin login and registration

### DIFF
--- a/app/Http/Controllers/AdminAuthController.php
+++ b/app/Http/Controllers/AdminAuthController.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Admin;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
+
+class AdminAuthController extends Controller
+{
+    public function showLoginForm()
+    {
+        return view('admin.login');
+    }
+
+    public function showRegisterForm()
+    {
+        return view('admin.register');
+    }
+
+    public function register(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+            'age' => 'required|integer',
+            'email' => 'required|email|unique:admins,email',
+            'document' => 'required|file',
+            'password' => 'required|confirmed|min:6',
+        ]);
+
+        $path = $request->file('document')->store('admins', 'public');
+
+        $admin = Admin::create([
+            'name' => $data['name'],
+            'age' => $data['age'],
+            'email' => $data['email'],
+            'document_path' => $path,
+            'password' => Hash::make($data['password']),
+            'api_token' => Str::random(60),
+        ]);
+
+        Auth::guard('admin')->login($admin);
+
+        return redirect()->route('drivers.index');
+    }
+
+    public function login(Request $request)
+    {
+        $credentials = $request->validate([
+            'email' => 'required|email',
+            'password' => 'required',
+        ]);
+
+        $admin = Admin::where('email', $credentials['email'])->first();
+        if (! $admin || ! Hash::check($credentials['password'], $admin->password)) {
+            return back()->withErrors(['email' => 'Invalid credentials']);
+        }
+
+        $admin->api_token = Str::random(60);
+        $admin->save();
+
+        Auth::guard('admin')->login($admin);
+
+        return redirect()->route('drivers.index');
+    }
+
+    public function logout(Request $request)
+    {
+        Auth::guard('admin')->logout();
+        return redirect()->route('admin.login');
+    }
+}

--- a/app/Models/Admin.php
+++ b/app/Models/Admin.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+
+class Admin extends Authenticatable
+{
+    use HasFactory, Notifiable;
+
+    protected $fillable = [
+        'name',
+        'age',
+        'email',
+        'document_path',
+        'password',
+        'api_token',
+    ];
+
+    protected $hidden = [
+        'password',
+        'remember_token',
+        'api_token',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'password' => 'hashed',
+        ];
+    }
+}

--- a/config/auth.php
+++ b/config/auth.php
@@ -40,6 +40,10 @@ return [
             'driver' => 'session',
             'provider' => 'users',
         ],
+        'admin' => [
+            'driver' => 'session',
+            'provider' => 'admins',
+        ],
     ],
 
     /*
@@ -63,6 +67,11 @@ return [
         'users' => [
             'driver' => 'eloquent',
             'model' => env('AUTH_MODEL', App\Models\User::class),
+        ],
+
+        'admins' => [
+            'driver' => 'eloquent',
+            'model' => App\Models\Admin::class,
         ],
 
         // 'users' => [

--- a/database/migrations/2025_06_11_130000_create_admins_table.php
+++ b/database/migrations/2025_06_11_130000_create_admins_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (Schema::hasTable('admins')) {
+            return;
+        }
+
+        Schema::create('admins', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->integer('age');
+            $table->string('email')->unique();
+            $table->string('document_path')->nullable();
+            $table->string('password');
+            $table->string('api_token', 80)->unique()->nullable();
+            $table->rememberToken();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('admins');
+    }
+};

--- a/resources/views/admin/login.blade.php
+++ b/resources/views/admin/login.blade.php
@@ -1,0 +1,20 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <h1>Admin Login</h1>
+    <form method="POST" action="{{ route('admin.login.submit') }}">
+        @csrf
+        <div class="mb-3">
+            <label class="form-label">Email</label>
+            <input type="email" name="email" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Password</label>
+            <input type="password" name="password" class="form-control" required>
+        </div>
+        <button type="submit" class="btn btn-primary">Login</button>
+        <a href="{{ route('admin.register') }}" class="btn btn-link">Register</a>
+    </form>
+</div>
+@endsection

--- a/resources/views/admin/register.blade.php
+++ b/resources/views/admin/register.blade.php
@@ -1,0 +1,35 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <h1>Admin Register</h1>
+    <form method="POST" action="{{ route('admin.register.submit') }}" enctype="multipart/form-data">
+        @csrf
+        <div class="mb-3">
+            <label class="form-label">Full Name</label>
+            <input type="text" name="name" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Age</label>
+            <input type="number" name="age" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Email</label>
+            <input type="email" name="email" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Document</label>
+            <input type="file" name="document" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Password</label>
+            <input type="password" name="password" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Confirm Password</label>
+            <input type="password" name="password_confirmation" class="form-control" required>
+        </div>
+        <button type="submit" class="btn btn-primary">Register</button>
+    </form>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\AdminAuthController;
 
 Route::get('/', function () {
     return redirect()->route('drivers.index');
@@ -9,6 +10,12 @@ Route::get('/', function () {
 Route::get('/we', function () {
     return view('welcome');
 });
+
+Route::get('/admin/login', [AdminAuthController::class, 'showLoginForm'])->name('admin.login');
+Route::post('/admin/login', [AdminAuthController::class, 'login'])->name('admin.login.submit');
+Route::get('/admin/register', [AdminAuthController::class, 'showRegisterForm'])->name('admin.register');
+Route::post('/admin/register', [AdminAuthController::class, 'register'])->name('admin.register.submit');
+Route::post('/admin/logout', [AdminAuthController::class, 'logout'])->name('admin.logout');
 
 Route::resource('drivers', App\Http\Controllers\DriverController::class);
 Route::put('drivers/{driver}/approve', [App\Http\Controllers\DriverController::class, 'approve'])->name('drivers.approve');


### PR DESCRIPTION
## Summary
- implement admins table migration
- create Admin model
- add authentication guard and provider for admins
- implement AdminAuthController for token-based admin login and register
- add admin login and registration views
- wire up admin auth routes

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684901da58a48329a03de4e9c269f406