### PR TITLE
Display admin email in navbar

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -14,6 +14,9 @@
                 <ul class="navbar-nav ms-auto">
                     @auth('admin')
                     <li class="nav-item">
+                        <span class="navbar-text">{{ auth('admin')->user()->email }}</span>
+                    </li>
+                    <li class="nav-item">
                         <form method="POST" action="{{ route('admin.logout') }}">
                             @csrf
                             <button type="submit" class="btn btn-link nav-link" style="display:inline; padding:0;">Logout</button>


### PR DESCRIPTION
## Summary
- show the currently logged-in admin's email address on the navigation bar above the Logout button

## Testing
- `php --version` *(fails: command not found)*
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684909a06aa483298bf15fdec65b4a6a