### PR TITLE
Add login pop-up feedback

### DIFF
--- a/app/Http/Controllers/AdminAuthController.php
+++ b/app/Http/Controllers/AdminAuthController.php
@@ -55,6 +55,9 @@ class AdminAuthController extends Controller
 
         $admin = Admin::where('email', $credentials['email'])->first();
         if (! $admin || ! Hash::check($credentials['password'], $admin->password)) {
+            if ($request->expectsJson()) {
+                return response()->json(['message' => 'Invalid credentials'], 422);
+            }
             return back()->withErrors(['email' => 'Invalid credentials']);
         }
 
@@ -62,6 +65,10 @@ class AdminAuthController extends Controller
         $admin->save();
 
         Auth::guard('admin')->login($admin);
+
+        if ($request->expectsJson()) {
+            return response()->json(['success' => true]);
+        }
 
         return redirect()->route('drivers.index');
     }

--- a/resources/views/admin/login.blade.php
+++ b/resources/views/admin/login.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 <div class="container">
     <h1>Admin Login</h1>
-    <form method="POST" action="{{ route('admin.login.submit') }}">
+    <form id="login-form" method="POST" action="{{ route('admin.login.submit') }}">
         @csrf
         <div class="mb-3">
             <label class="form-label">Email</label>
@@ -16,5 +16,61 @@
         <button type="submit" class="btn btn-primary">Login</button>
         <a href="{{ route('admin.register') }}" class="btn btn-link">Register</a>
     </form>
+
+    <!-- Modal for login notifications -->
+    <div class="modal fade" id="loginModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-body text-center" id="loginModalMessage"></div>
+            </div>
+        </div>
+    </div>
 </div>
+@endsection
+
+@section('scripts')
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    const form = document.getElementById('login-form');
+    const modalEl = document.getElementById('loginModal');
+    const modal = new bootstrap.Modal(modalEl);
+    const messageEl = document.getElementById('loginModalMessage');
+
+    form.addEventListener('submit', function (e) {
+        e.preventDefault();
+
+        const formData = new FormData(form);
+        fetch(form.action, {
+            method: 'POST',
+            headers: {
+                'X-CSRF-TOKEN': document.querySelector('input[name="_token"]').value,
+                'Accept': 'application/json'
+            },
+            body: formData
+        })
+        .then(resp => {
+            if (resp.ok) {
+                return resp.json().catch(() => ({ success: true }));
+            }
+            throw new Error('fail');
+        })
+        .then(() => {
+            messageEl.textContent = 'Login Success';
+            modal.show();
+            setTimeout(() => {
+                modal.hide();
+                window.location.href = "{{ route('drivers.index') }}";
+            }, 2000);
+        })
+        .catch(() => {
+            messageEl.textContent = 'Login Fail';
+            modal.show();
+            setTimeout(() => {
+                modal.hide();
+                form.reset();
+            }, 2000);
+        });
+    });
+});
+</script>
 @endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -35,5 +35,7 @@
         </div>
     @endif
     @yield('content')
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    @yield('scripts')
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show login result in a Bootstrap modal and delay redirect or reset
- allow AdminAuthController to return JSON responses
- include Bootstrap JS and yield page scripts in layout

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68490c234d3c8329b2a45b1eba06ec34