### PR TITLE
Disable admin panel on logout

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -9,7 +9,11 @@
 <body>
     <nav class="navbar navbar-expand-lg navbar-light bg-light mb-3">
         <div class="container">
-            <a class="navbar-brand" href="{{ route('drivers.index') }}">Admin Panel</a>
+            @auth('admin')
+                <a class="navbar-brand" href="{{ route('drivers.index') }}">Admin Panel</a>
+            @else
+                <span class="navbar-brand text-muted">Admin Panel</span>
+            @endauth
             <div class="collapse navbar-collapse">
                 <ul class="navbar-nav ms-auto">
                     @auth('admin')

--- a/resources/views/layouts/sneat.blade.php
+++ b/resources/views/layouts/sneat.blade.php
@@ -15,7 +15,11 @@
         <div class="layout-container">
             <nav class="layout-navbar navbar navbar-expand-lg align-items-center bg-navbar-theme">
                 <div class="container-fluid">
-                    <a class="navbar-brand" href="{{ route('drivers.index') }}">Admin Panel</a>
+                    @auth('admin')
+                        <a class="navbar-brand" href="{{ route('drivers.index') }}">Admin Panel</a>
+                    @else
+                        <span class="navbar-brand text-muted">Admin Panel</span>
+                    @endauth
                     <ul class="navbar-nav ms-auto">
                         @auth('admin')
                         <li class="nav-item d-flex align-items-center me-2">


### PR DESCRIPTION
## Summary
- adjust layout so Admin Panel link is only clickable for logged in admins

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68492369d3148329add869a5ff84b2a2