### PR TITLE
Implement driver status stages and editing

### DIFF
--- a/app/Models/Driver.php
+++ b/app/Models/Driver.php
@@ -28,6 +28,6 @@ class Driver extends Model
         'compulsory_insurance_path',
         'vehicle_insurance_path',
         'service_type',
-        'approved',
+        'status',
     ];
 }

--- a/database/migrations/2025_06_11_080819_add_status_to_drivers_table.php
+++ b/database/migrations/2025_06_11_080819_add_status_to_drivers_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('drivers', function (Blueprint $table) {
+            if (Schema::hasColumn('drivers', 'approved')) {
+                $table->dropColumn('approved');
+            }
+            $table->enum('status', ['No_approve', 'Pending', 'Approved'])->default('Pending')->after('service_type');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('drivers', function (Blueprint $table) {
+            $table->dropColumn('status');
+            $table->boolean('approved')->default(false);
+        });
+    }
+};

--- a/resources/views/drivers/index.blade.php
+++ b/resources/views/drivers/index.blade.php
@@ -11,7 +11,7 @@
                 <th>Name</th>
                 <th>Phone</th>
                 <th>Service</th>
-                <th>Approved</th>
+                <th>Status</th>
                 <th>Actions</th>
             </tr>
         </thead>
@@ -22,10 +22,10 @@
                 <td>{{ $driver->full_name }}</td>
                 <td>{{ $driver->phone }}</td>
                 <td>{{ $driver->service_type }}</td>
-                <td>{{ $driver->approved ? 'Yes' : 'No' }}</td>
+                <td>{{ $driver->status }}</td>
                 <td>
                     <a href="{{ route('drivers.show', $driver) }}" class="btn btn-sm btn-info">More information</a>
-                    @if(!$driver->approved)
+                    @if($driver->status !== 'Approved')
                     <form action="{{ route('drivers.approve', $driver) }}" method="POST" style="display:inline;">
                         @csrf
                         @method('PUT')

--- a/resources/views/drivers/show.blade.php
+++ b/resources/views/drivers/show.blade.php
@@ -4,63 +4,95 @@
 <div class="container">
     <h1>Driver Details</h1>
     <a href="{{ route('drivers.index') }}" class="btn btn-secondary mb-3">Back</a>
-    <table class="table table-bordered">
-        <tr>
-            <th>ID</th>
-            <td>{{ $driver->id }}</td>
-        </tr>
-        <tr>
-            <th>Name</th>
-            <td>{{ $driver->full_name }}</td>
-        </tr>
-        <tr>
-            <th>Phone</th>
-            <td>{{ $driver->phone }}</td>
-        </tr>
-        <tr>
-            <th>Email</th>
-            <td>{{ $driver->email }}</td>
-        </tr>
-        <tr>
-            <th>Birthdate</th>
-            <td>{{ $driver->birthdate }}</td>
-        </tr>
-        <tr>
-            <th>Gender</th>
-            <td>{{ $driver->gender }}</td>
-        </tr>
-        <tr>
-            <th>Service</th>
-            <td>{{ $driver->service_type }}</td>
-        </tr>
-        <tr>
-            <th>Approved</th>
-            <td>{{ $driver->approved ? 'Yes' : 'No' }}</td>
-        </tr>
-        <tr>
-            <th>ID Card</th>
-            <td><a href="{{ route('drivers.download', [$driver, 'id_card']) }}">{{ basename($driver->id_card_path) }}</a></td>
-        </tr>
-        <tr>
-            <th>Driver License</th>
-            <td><a href="{{ route('drivers.download', [$driver, 'driver_license']) }}">{{ basename($driver->driver_license_path) }}</a></td>
-        </tr>
-        <tr>
-            <th>Face Photo</th>
-            <td><a href="{{ route('drivers.download', [$driver, 'face_photo']) }}">{{ basename($driver->face_photo_path) }}</a></td>
-        </tr>
-        <tr>
-            <th>Vehicle Registration</th>
-            <td><a href="{{ route('drivers.download', [$driver, 'vehicle_registration']) }}">{{ basename($driver->vehicle_registration_path) }}</a></td>
-        </tr>
-        <tr>
-            <th>Compulsory Insurance</th>
-            <td><a href="{{ route('drivers.download', [$driver, 'compulsory_insurance']) }}">{{ basename($driver->compulsory_insurance_path) }}</a></td>
-        </tr>
-        <tr>
-            <th>Vehicle Insurance</th>
-            <td><a href="{{ route('drivers.download', [$driver, 'vehicle_insurance']) }}">{{ basename($driver->vehicle_insurance_path) }}</a></td>
-        </tr>
-    </table>
+
+    <form action="{{ route('drivers.update', $driver) }}" method="POST" enctype="multipart/form-data">
+        @csrf
+        @method('PUT')
+
+        <div class="mb-3">
+            <label class="form-label">Full Name</label>
+            <input type="text" name="full_name" class="form-control" value="{{ $driver->full_name }}" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Phone</label>
+            <input type="text" name="phone" class="form-control" value="{{ $driver->phone }}" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Email</label>
+            <input type="email" name="email" class="form-control" value="{{ $driver->email }}">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Birthdate</label>
+            <input type="date" name="birthdate" class="form-control" value="{{ $driver->birthdate }}">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Gender</label>
+            <select name="gender" class="form-select">
+                <option value="male" @selected($driver->gender == 'male')>Male</option>
+                <option value="female" @selected($driver->gender == 'female')>Female</option>
+            </select>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Service Type</label>
+            <select name="service_type" class="form-select" required>
+                <option value="car" @selected($driver->service_type == 'car')>Car</option>
+                <option value="motorcycle" @selected($driver->service_type == 'motorcycle')>Motorcycle</option>
+                <option value="delivery" @selected($driver->service_type == 'delivery')>Delivery</option>
+            </select>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Status</label>
+            <select name="status" class="form-select" required>
+                <option value="No_approve" @selected($driver->status == 'No_approve')>No approve</option>
+                <option value="Pending" @selected($driver->status == 'Pending')>Pending</option>
+                <option value="Approved" @selected($driver->status == 'Approved')>Approved</option>
+            </select>
+        </div>
+
+        <div class="mb-3">
+            <label class="form-label">ID Card</label>
+            <input type="file" name="id_card" class="form-control">
+            @if($driver->id_card_path)
+            <a href="{{ route('drivers.download', [$driver, 'id_card']) }}" class="d-block mt-1">{{ basename($driver->id_card_path) }}</a>
+            @endif
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Driver License</label>
+            <input type="file" name="driver_license" class="form-control">
+            @if($driver->driver_license_path)
+            <a href="{{ route('drivers.download', [$driver, 'driver_license']) }}" class="d-block mt-1">{{ basename($driver->driver_license_path) }}</a>
+            @endif
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Face Photo</label>
+            <input type="file" name="face_photo" class="form-control">
+            @if($driver->face_photo_path)
+            <a href="{{ route('drivers.download', [$driver, 'face_photo']) }}" class="d-block mt-1">{{ basename($driver->face_photo_path) }}</a>
+            @endif
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Vehicle Registration</label>
+            <input type="file" name="vehicle_registration" class="form-control">
+            @if($driver->vehicle_registration_path)
+            <a href="{{ route('drivers.download', [$driver, 'vehicle_registration']) }}" class="d-block mt-1">{{ basename($driver->vehicle_registration_path) }}</a>
+            @endif
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Compulsory Insurance</label>
+            <input type="file" name="compulsory_insurance" class="form-control">
+            @if($driver->compulsory_insurance_path)
+            <a href="{{ route('drivers.download', [$driver, 'compulsory_insurance']) }}" class="d-block mt-1">{{ basename($driver->compulsory_insurance_path) }}</a>
+            @endif
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Vehicle Insurance</label>
+            <input type="file" name="vehicle_insurance" class="form-control">
+            @if($driver->vehicle_insurance_path)
+            <a href="{{ route('drivers.download', [$driver, 'vehicle_insurance']) }}" class="d-block mt-1">{{ basename($driver->vehicle_insurance_path) }}</a>
+            @endif
+        </div>
+
+        <button type="submit" class="btn btn-primary">Save</button>
+    </form>
 </div>
 @endsection


### PR DESCRIPTION
## Summary
- add migration to introduce `status` field on drivers
- update model fillable fields
- allow editing all driver fields from "More information" page
- show status column in driver list
- set status to `Approved` when approving a driver

## Testing
- `./vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_684938f9e7948329a7708c865537abc9