### PR TITLE
Implement super admin features

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Admin;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+
+class AdminController extends Controller
+{
+    private function authorizeSuper()
+    {
+        if (!auth('admin')->check()) {
+            abort(403);
+        }
+        if (!auth('admin')->user()->is_super) {
+            abort(403);
+        }
+    }
+
+    public function index()
+    {
+        $this->authorizeSuper();
+        $admins = Admin::all();
+        return view('admins.index', compact('admins'));
+    }
+
+    public function create()
+    {
+        $this->authorizeSuper();
+        return view('admins.create');
+    }
+
+    public function store(Request $request)
+    {
+        $this->authorizeSuper();
+        $data = $request->validate([
+            'name' => 'required|string',
+            'age' => 'required|integer',
+            'email' => 'required|email|unique:admins,email',
+            'password' => 'required|string',
+            'is_super' => 'sometimes|boolean',
+        ]);
+
+        $data['api_token'] = Str::random(60);
+        $data['is_super'] = $request->boolean('is_super');
+        Admin::create($data);
+
+        return redirect()->route('admins.index');
+    }
+
+    public function edit(string $id)
+    {
+        $this->authorizeSuper();
+        $admin = Admin::findOrFail($id);
+        return view('admins.edit', compact('admin'));
+    }
+
+    public function update(Request $request, string $id)
+    {
+        $this->authorizeSuper();
+        $admin = Admin::findOrFail($id);
+        $data = $request->validate([
+            'name' => 'required|string',
+            'age' => 'required|integer',
+            'email' => 'required|email|unique:admins,email,'.$admin->id,
+            'password' => 'nullable|string',
+            'is_super' => 'sometimes|boolean',
+        ]);
+        if ($request->filled('password')) {
+            $admin->password = Hash::make($data['password']);
+        }
+        $admin->name = $data['name'];
+        $admin->age = $data['age'];
+        $admin->email = $data['email'];
+        $admin->is_super = $request->boolean('is_super');
+        $admin->save();
+
+        return redirect()->route('admins.index');
+    }
+
+    public function destroy(string $id)
+    {
+        $this->authorizeSuper();
+        $admin = Admin::findOrFail($id);
+        $admin->delete();
+        return redirect()->route('admins.index');
+    }
+}

--- a/app/Models/Admin.php
+++ b/app/Models/Admin.php
@@ -16,6 +16,7 @@ class Admin extends Authenticatable
         'email',
         'password',
         'api_token',
+        'is_super',
     ];
 
     protected $hidden = [
@@ -28,6 +29,7 @@ class Admin extends Authenticatable
     {
         return [
             'password' => 'hashed',
+            'is_super' => 'boolean',
         ];
     }
 }

--- a/database/migrations/2025_06_11_140001_add_is_super_to_admins_table.php
+++ b/database/migrations/2025_06_11_140001_add_is_super_to_admins_table.php
@@ -1,0 +1,23 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        if (Schema::hasColumn('admins', 'is_super')) {
+            return;
+        }
+        Schema::table('admins', function (Blueprint $table) {
+            $table->boolean('is_super')->default(false);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('admins', function (Blueprint $table) {
+            $table->dropColumn('is_super');
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use App\Models\User;
 use Database\Seeders\AdminSeeder;
+use Database\Seeders\SuperAdminSeeder;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -21,6 +22,9 @@ class DatabaseSeeder extends Seeder
             'email' => 'test@example.com',
         ]);
 
-        $this->call(AdminSeeder::class);
+        $this->call([
+            AdminSeeder::class,
+            SuperAdminSeeder::class,
+        ]);
     }
 }

--- a/database/seeders/SuperAdminSeeder.php
+++ b/database/seeders/SuperAdminSeeder.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Admin;
+use Illuminate\Support\Str;
+
+class SuperAdminSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $supers = [
+            [
+                'name' => 'Super One',
+                'age' => 45,
+                'email' => 'super1@example.com',
+                'password' => 'superpass1',
+            ],
+            [
+                'name' => 'Super Two',
+                'age' => 50,
+                'email' => 'super2@example.com',
+                'password' => 'superpass2',
+            ],
+        ];
+
+        foreach ($supers as $super) {
+            Admin::create($super + [
+                'api_token' => Str::random(60),
+                'is_super' => true,
+            ]);
+        }
+    }
+}

--- a/resources/views/admins/create.blade.php
+++ b/resources/views/admins/create.blade.php
@@ -1,0 +1,32 @@
+@extends('layouts.sneat')
+
+@section('content')
+<div class="container">
+    <h1>Add Admin</h1>
+    <a href="{{ route('admins.index') }}" class="btn btn-secondary mb-3">Back</a>
+    <form action="{{ route('admins.store') }}" method="POST">
+        @csrf
+        <div class="mb-3">
+            <label class="form-label">Name</label>
+            <input type="text" name="name" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Age</label>
+            <input type="number" name="age" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Email</label>
+            <input type="email" name="email" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Password</label>
+            <input type="password" name="password" class="form-control" required>
+        </div>
+        <div class="form-check mb-3">
+            <input class="form-check-input" type="checkbox" name="is_super" id="is_super">
+            <label class="form-check-label" for="is_super">Super Admin</label>
+        </div>
+        <button type="submit" class="btn btn-primary">Save</button>
+    </form>
+</div>
+@endsection

--- a/resources/views/admins/edit.blade.php
+++ b/resources/views/admins/edit.blade.php
@@ -1,0 +1,33 @@
+@extends('layouts.sneat')
+
+@section('content')
+<div class="container">
+    <h1>Edit Admin</h1>
+    <a href="{{ route('admins.index') }}" class="btn btn-secondary mb-3">Back</a>
+    <form action="{{ route('admins.update', $admin) }}" method="POST">
+        @csrf
+        @method('PUT')
+        <div class="mb-3">
+            <label class="form-label">Name</label>
+            <input type="text" name="name" class="form-control" value="{{ $admin->name }}" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Age</label>
+            <input type="number" name="age" class="form-control" value="{{ $admin->age }}" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Email</label>
+            <input type="email" name="email" class="form-control" value="{{ $admin->email }}" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Password (leave blank to keep current)</label>
+            <input type="password" name="password" class="form-control">
+        </div>
+        <div class="form-check mb-3">
+            <input class="form-check-input" type="checkbox" name="is_super" id="is_super" @checked($admin->is_super)>
+            <label class="form-check-label" for="is_super">Super Admin</label>
+        </div>
+        <button type="submit" class="btn btn-primary">Save</button>
+    </form>
+</div>
+@endsection

--- a/resources/views/admins/index.blade.php
+++ b/resources/views/admins/index.blade.php
@@ -1,0 +1,37 @@
+@extends('layouts.sneat')
+
+@section('content')
+<div class="container">
+    <h1>Admins</h1>
+    <a href="{{ route('admins.create') }}" class="btn btn-primary mb-3">Add Admin</a>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Name</th>
+                <th>Email</th>
+                <th>Super</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($admins as $a)
+            <tr>
+                <td>{{ $a->id }}</td>
+                <td>{{ $a->name }}</td>
+                <td>{{ $a->email }}</td>
+                <td>{{ $a->is_super ? 'Yes' : 'No' }}</td>
+                <td>
+                    <a href="{{ route('admins.edit', $a) }}" class="btn btn-sm btn-info">Edit</a>
+                    <form action="{{ route('admins.destroy', $a) }}" method="POST" style="display:inline;">
+                        @csrf
+                        @method('DELETE')
+                        <button class="btn btn-sm btn-danger" onclick="return confirm('Delete?')">Delete</button>
+                    </form>
+                </td>
+            </tr>
+            @endforeach
+        </tbody>
+    </table>
+</div>
+@endsection

--- a/resources/views/layouts/sneat.blade.php
+++ b/resources/views/layouts/sneat.blade.php
@@ -20,6 +20,18 @@
                     <span class="navbar-brand text-muted ps-4">Admin Panel</span>
                 @endauth
                 <div class="container-fluid">
+                    @auth('admin')
+                    <ul class="navbar-nav me-auto">
+                        <li class="nav-item">
+                            <a class="nav-link text-white" href="{{ route('drivers.index') }}">Drivers</a>
+                        </li>
+                        @if(auth('admin')->user()->is_super)
+                        <li class="nav-item">
+                            <a class="nav-link text-white" href="{{ route('admins.index') }}">Admins</a>
+                        </li>
+                        @endif
+                    </ul>
+                    @endauth
                     <ul class="navbar-nav ms-auto">
                         @auth('admin')
                         <li class="nav-item d-flex align-items-center me-2">

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,3 +18,5 @@ Route::post('/admin/logout', [AdminAuthController::class, 'logout'])->name('admi
 Route::resource('drivers', App\Http\Controllers\DriverController::class);
 Route::put('drivers/{driver}/approve', [App\Http\Controllers\DriverController::class, 'approve'])->name('drivers.approve');
 Route::get('drivers/{driver}/download/{field}', [App\Http\Controllers\DriverController::class, 'download'])->name('drivers.download');
+
+Route::resource('admins', App\Http\Controllers\AdminController::class);


### PR DESCRIPTION
## Summary
- allow Admin model to track super status
- create migration for is_super column
- add SuperAdminSeeder and call it from DatabaseSeeder
- add AdminController for super admin management
- expose Admin management routes and views
- show admin management in navbar when logged in as super admin

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68493f26996483298acdf53447e1c8c1