### PR TITLE
Fix duplicate entry errors in seeders

### DIFF
--- a/database/seeders/AdminSeeder.php
+++ b/database/seeders/AdminSeeder.php
@@ -44,7 +44,10 @@ class AdminSeeder extends Seeder
         ];
 
         foreach ($admins as $admin) {
-            Admin::create($admin + ['api_token' => Str::random(60)]);
+            Admin::firstOrCreate(
+                ['email' => $admin['email']],
+                $admin + ['api_token' => Str::random(60)]
+            );
         }
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -17,10 +17,13 @@ class DatabaseSeeder extends Seeder
     {
         // User::factory(10)->create();
 
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
+        // Ensure the default test user only gets created once
+        if (! User::where('email', 'test@example.com')->exists()) {
+            User::factory()->create([
+                'name' => 'Test User',
+                'email' => 'test@example.com',
+            ]);
+        }
 
         $this->call([
             AdminSeeder::class,

--- a/database/seeders/SuperAdminSeeder.php
+++ b/database/seeders/SuperAdminSeeder.php
@@ -26,10 +26,13 @@ class SuperAdminSeeder extends Seeder
         ];
 
         foreach ($supers as $super) {
-            Admin::create($super + [
-                'api_token' => Str::random(60),
-                'is_super' => true,
-            ]);
+            Admin::firstOrCreate(
+                ['email' => $super['email']],
+                $super + [
+                    'api_token' => Str::random(60),
+                    'is_super' => true,
+                ]
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure the `Test User` is only created once
- guard against duplicate admin emails in the seeders

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684940e34d7083299ff340c98f738a6e