### PR TITLE
Add admin auth guard to routes

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -12,11 +12,17 @@ Route::get('/we', function () {
 });
 
 Route::get('/admin/login', [AdminAuthController::class, 'showLoginForm'])->name('admin.login');
+// Additional alias so the auth middleware can redirect unauthorized users
+Route::get('/login', function () {
+    return redirect()->route('admin.login');
+})->name('login');
 Route::post('/admin/login', [AdminAuthController::class, 'login'])->name('admin.login.submit');
 Route::post('/admin/logout', [AdminAuthController::class, 'logout'])->name('admin.logout');
 
-Route::resource('drivers', App\Http\Controllers\DriverController::class);
-Route::put('drivers/{driver}/approve', [App\Http\Controllers\DriverController::class, 'approve'])->name('drivers.approve');
-Route::get('drivers/{driver}/download/{field}', [App\Http\Controllers\DriverController::class, 'download'])->name('drivers.download');
+Route::middleware('auth:admin')->group(function () {
+    Route::resource('drivers', App\Http\Controllers\DriverController::class);
+    Route::put('drivers/{driver}/approve', [App\Http\Controllers\DriverController::class, 'approve'])->name('drivers.approve');
+    Route::get('drivers/{driver}/download/{field}', [App\Http\Controllers\DriverController::class, 'download'])->name('drivers.download');
 
-Route::resource('admins', App\Http\Controllers\AdminController::class);
+    Route::resource('admins', App\Http\Controllers\AdminController::class);
+});

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -16,4 +16,11 @@ class ExampleTest extends TestCase
 
         $response->assertStatus(302);
     }
+
+    public function test_guests_are_redirected_to_login_when_accessing_drivers(): void
+    {
+        $response = $this->get('/drivers');
+
+        $response->assertRedirect('/login');
+    }
 }


### PR DESCRIPTION
## Summary
- require login on driver and admin routes
- redirect unauthenticated users to `/login`
- test that guests are redirected

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6849476a4bc88329862f44a8f21395ef