### PR TITLE
Prevent admins from revisiting login while authenticated

### DIFF
--- a/app/Http/Controllers/AdminAuthController.php
+++ b/app/Http/Controllers/AdminAuthController.php
@@ -12,6 +12,10 @@ class AdminAuthController extends Controller
 {
     public function showLoginForm()
     {
+        if (Auth::guard('admin')->check()) {
+            return redirect()->route('drivers.index');
+        }
+
         return view('admin.login');
     }
 


### PR DESCRIPTION
## Summary
- stop authenticated admins from revisiting the login page unless they log out

## Testing
- `npm --version`
- `composer --version` *(fails: command not found)*
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68494a71920c8329860a7d990a3971e2