### PR TITLE
Add middleware for admin login verification

### DIFF
--- a/app/Http/Controllers/AdminAuthController.php
+++ b/app/Http/Controllers/AdminAuthController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers;
 
 use App\Models\Admin;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Str;
 
@@ -22,16 +21,13 @@ class AdminAuthController extends Controller
 
     public function login(Request $request)
     {
-        $credentials = $request->validate([
-            'email' => 'required|email',
-            'password' => 'required',
-        ]);
-
-        $admin = Admin::where('email', $credentials['email'])->first();
-        if (! $admin || ! Hash::check($credentials['password'], $admin->password)) {
+        /** @var \App\Models\Admin|null $admin */
+        $admin = $request->attributes->get('admin');
+        if (! $admin) {
             if ($request->expectsJson()) {
                 return response()->json(['message' => 'Invalid credentials'], 422);
             }
+
             return back()->withErrors(['email' => 'Invalid credentials']);
         }
 

--- a/app/Http/Middleware/VerifyAdminCredentials.php
+++ b/app/Http/Middleware/VerifyAdminCredentials.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use App\Models\Admin;
+
+class VerifyAdminCredentials
+{
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $credentials = $request->validate([
+            'email' => 'required|email',
+            'password' => 'required',
+        ]);
+
+        $admin = Admin::where('email', $credentials['email'])->first();
+        if (! $admin || ! Hash::check($credentials['password'], $admin->password)) {
+            if ($request->expectsJson()) {
+                return response()->json(['message' => 'Invalid credentials'], 422);
+            }
+
+            return redirect()->back()->withErrors(['email' => 'Invalid credentials']);
+        }
+
+        $request->attributes->set('admin', $admin);
+
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,6 +3,7 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use App\Http\Middleware\VerifyAdminCredentials;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -11,7 +12,7 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->alias('verify.admin.credentials', VerifyAdminCredentials::class);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,7 +16,9 @@ Route::get('/admin/login', [AdminAuthController::class, 'showLoginForm'])->name(
 Route::get('/login', function () {
     return redirect()->route('admin.login');
 })->name('login');
-Route::post('/admin/login', [AdminAuthController::class, 'login'])->name('admin.login.submit');
+Route::post('/admin/login', [AdminAuthController::class, 'login'])
+    ->middleware('verify.admin.credentials')
+    ->name('admin.login.submit');
 Route::post('/admin/logout', [AdminAuthController::class, 'logout'])->name('admin.logout');
 
 Route::middleware('auth:admin')->group(function () {


### PR DESCRIPTION
## Summary
- implement `VerifyAdminCredentials` middleware
- register middleware alias in `bootstrap/app.php`
- use middleware on `/admin/login` route
- simplify `AdminAuthController` to rely on middleware

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684a3c79b4cc83298232928d812b68d9