### PR TITLE
Fix middleware alias signature

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -12,7 +12,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        $middleware->alias('verify.admin.credentials', VerifyAdminCredentials::class);
+        $middleware->alias([
+            'verify.admin.credentials' => VerifyAdminCredentials::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //


### PR DESCRIPTION
## Summary
- fix middleware alias usage in `bootstrap/app.php`

## Testing
- `composer install` *(fails: composer not found)*
- `php -v` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a3ebd7e6483298321e2b04a962e2e