### PR TITLE
Add request validation middleware

### DIFF
--- a/app/Http/Middleware/ValidateRequests.php
+++ b/app/Http/Middleware/ValidateRequests.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class ValidateRequests
+{
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $route = $request->route();
+        $name = $route?->getName();
+
+        switch ($name) {
+            case 'drivers.store':
+                $request->validate([
+                    'full_name' => 'required|string',
+                    'phone' => 'required|string',
+                    'email' => 'nullable|email',
+                    'birthdate' => 'nullable|date',
+                    'gender' => 'nullable|string',
+                    'password_for_profile' => 'nullable|string',
+                    'bank_account' => 'required|digits_between:1,14',
+                    'service_type' => 'required|in:car,motorcycle,delivery',
+                    'id_card' => 'required|file',
+                    'driver_license' => 'required|file',
+                    'face_photo' => 'required|file',
+                    'vehicle_registration' => 'required|file',
+                    'compulsory_insurance' => 'required|file',
+                    'vehicle_insurance' => 'required|file',
+                ]);
+                break;
+            case 'drivers.update':
+                $request->validate([
+                    'full_name' => 'required|string',
+                    'phone' => 'required|string',
+                    'email' => 'nullable|email',
+                    'birthdate' => 'nullable|date',
+                    'gender' => 'nullable|string',
+                    'password_for_profile' => 'nullable|string',
+                    'bank_account' => 'required|digits_between:1,14',
+                    'service_type' => 'required|in:car,motorcycle,delivery',
+                    'status' => 'required|in:No_approve,Pending,Approved',
+                    'id_card' => 'nullable|file',
+                    'driver_license' => 'nullable|file',
+                    'face_photo' => 'nullable|file',
+                    'vehicle_registration' => 'nullable|file',
+                    'compulsory_insurance' => 'nullable|file',
+                    'vehicle_insurance' => 'nullable|file',
+                ]);
+                break;
+            case 'drivers.approve':
+                $request->validate([
+                    'status' => 'in:No_approve,Pending,Approved',
+                ]);
+                break;
+            case 'drivers.download':
+                $request->validate([
+                    'field' => 'in:id_card,driver_license,face_photo,vehicle_registration,compulsory_insurance,vehicle_insurance',
+                ]);
+                break;
+            case 'admins.store':
+                $request->validate([
+                    'name' => 'required|string',
+                    'age' => 'required|integer',
+                    'email' => 'required|email|unique:admins,email',
+                    'password' => 'required|string',
+                    'is_super' => 'sometimes|boolean',
+                ]);
+                break;
+            case 'admins.update':
+                $adminId = $request->route('admin');
+                if (is_object($adminId) && method_exists($adminId, 'getKey')) {
+                    $adminId = $adminId->getKey();
+                }
+                $request->validate([
+                    'name' => 'required|string',
+                    'age' => 'required|integer',
+                    'email' => 'required|email|unique:admins,email,'.$adminId,
+                    'password' => 'nullable|string',
+                    'is_super' => 'sometimes|boolean',
+                ]);
+                break;
+        }
+
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,9 +1,9 @@
 <?php
 
+use App\Http\Middleware\VerifyAdminCredentials;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
-use App\Http\Middleware\VerifyAdminCredentials;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -14,6 +14,7 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->alias([
             'verify.admin.credentials' => VerifyAdminCredentials::class,
+            'validate.request' => App\Http\Middleware\ValidateRequests::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/database/factories/AdminFactory.php
+++ b/database/factories/AdminFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Admin;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Admin>
+ */
+class AdminFactory extends Factory
+{
+    protected $model = Admin::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->name(),
+            'age' => $this->faker->numberBetween(20, 60),
+            'email' => $this->faker->unique()->safeEmail(),
+            'password' => 'password',
+            'api_token' => Str::random(60),
+            'is_super' => false,
+        ];
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,7 +1,7 @@
 <?php
 
-use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AdminAuthController;
+use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return redirect()->route('admin.login');
@@ -21,7 +21,7 @@ Route::post('/admin/login', [AdminAuthController::class, 'login'])
     ->name('admin.login.submit');
 Route::post('/admin/logout', [AdminAuthController::class, 'logout'])->name('admin.logout');
 
-Route::middleware('auth:admin')->group(function () {
+Route::middleware(['auth:admin', 'validate.request'])->group(function () {
     Route::resource('drivers', App\Http\Controllers\DriverController::class);
     Route::put('drivers/{driver}/approve', [App\Http\Controllers\DriverController::class, 'approve'])->name('drivers.approve');
     Route::get('drivers/{driver}/download/{field}', [App\Http\Controllers\DriverController::class, 'download'])->name('drivers.download');

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -23,4 +23,22 @@ class ExampleTest extends TestCase
 
         $response->assertRedirect('/login');
     }
+
+    public function test_driver_store_validation_runs_via_middleware(): void
+    {
+        $admin = new \App\Models\Admin([
+            'id' => 1,
+            'name' => 'Test Admin',
+            'age' => 30,
+            'email' => 'admin@example.com',
+            'password' => 'password',
+            'api_token' => 'token',
+            'is_super' => true,
+        ]);
+        $this->actingAs($admin, 'admin');
+
+        $response = $this->post('/drivers', []);
+
+        $response->assertSessionHasErrors(['full_name']);
+    }
 }


### PR DESCRIPTION
## Summary
- create `ValidateRequests` middleware for route-specific validation
- register middleware alias in `bootstrap/app.php`
- apply middleware to authenticated routes
- provide `AdminFactory` for testing
- add a feature test verifying middleware validation

## Testing
- `php artisan test --testsuite Feature --log-junit /tmp/junit.xml`

------
https://chatgpt.com/codex/tasks/task_e_684a401236548329a3bc2f61b3b7e918