### PR TITLE
Add API endpoints for drivers with token auth

### DIFF
--- a/app/Http/Controllers/AdminAuthController.php
+++ b/app/Http/Controllers/AdminAuthController.php
@@ -37,7 +37,9 @@ class AdminAuthController extends Controller
         Auth::guard('admin')->login($admin);
 
         if ($request->expectsJson()) {
-            return response()->json(['success' => true]);
+            return response()->json([
+                'token' => $admin->api_token,
+            ]);
         }
 
         return redirect()->route('drivers.index');

--- a/app/Http/Controllers/Api/DriverController.php
+++ b/app/Http/Controllers/Api/DriverController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Models\Driver;
+
+class DriverController extends Controller
+{
+    public function index()
+    {
+        return response()->json(
+            Driver::select('id','full_name','phone','email','password_for_profile','bank_account','birthdate','gender','service_type','status')->get()
+        );
+    }
+
+    public function show(string $id)
+    {
+        $driver = Driver::select('id','full_name','phone','email','password_for_profile','bank_account','birthdate','gender','service_type','status')
+            ->findOrFail($id);
+        return response()->json($driver);
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'full_name' => 'required|string',
+            'phone' => 'required|string',
+            'email' => 'nullable|email',
+            'birthdate' => 'nullable|date',
+            'gender' => 'nullable|string',
+            'password_for_profile' => 'nullable|string',
+            'bank_account' => 'required|digits_between:1,14',
+            'service_type' => 'required|in:car,motorcycle,delivery',
+        ]);
+        $data['status'] = 'Pending';
+
+        $driver = Driver::create($data);
+
+        return response()->json($driver, 201);
+    }
+}
+

--- a/app/Http/Middleware/AuthenticateApiToken.php
+++ b/app/Http/Middleware/AuthenticateApiToken.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use App\Models\Admin;
+
+class AuthenticateApiToken
+{
+    public function handle(Request $request, Closure $next)
+    {
+        $token = $request->bearerToken();
+        if (! $token) {
+            return response()->json(['message' => 'Unauthenticated'], 401);
+        }
+
+        $admin = Admin::where('api_token', $token)->first();
+        if (! $admin) {
+            return response()->json(['message' => 'Unauthenticated'], 401);
+        }
+
+        $request->setUserResolver(fn () => $admin);
+
+        return $next($request);
+    }
+}
+

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
@@ -15,6 +16,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->alias([
             'verify.admin.credentials' => VerifyAdminCredentials::class,
             'validate.request' => App\Http\Middleware\ValidateRequests::class,
+            'auth.api' => App\Http\Middleware\AuthenticateApiToken::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Api\DriverController;
+use App\Http\Controllers\AdminAuthController;
+
+Route::post('/login', [AdminAuthController::class, 'login'])
+    ->middleware('verify.admin.credentials');
+
+Route::middleware('auth.api')->group(function () {
+    Route::get('/drivers', [DriverController::class, 'index']);
+    Route::post('/drivers', [DriverController::class, 'store']);
+    Route::get('/drivers/{driver}', [DriverController::class, 'show']);
+});
+


### PR DESCRIPTION
## Summary
- implement API routes for driver operations
- create API driver controller and token auth middleware
- update admin login JSON response to return API token
- enable API routes in bootstrap configuration

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_684a427b86e48329b27d731520e148f2