### PR TITLE
Add Sanctum token auth for API

### DIFF
--- a/app/Http/Controllers/AdminAuthController.php
+++ b/app/Http/Controllers/AdminAuthController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers;
 use App\Models\Admin;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Str;
 
 class AdminAuthController extends Controller
 {
@@ -31,14 +30,14 @@ class AdminAuthController extends Controller
             return back()->withErrors(['email' => 'Invalid credentials']);
         }
 
-        $admin->api_token = Str::random(60);
-        $admin->save();
+        /** @var \App\Models\Admin $admin */
+        $token = $admin->createToken('api-token')->plainTextToken;
 
         Auth::guard('admin')->login($admin);
 
         if ($request->expectsJson()) {
             return response()->json([
-                'token' => $admin->api_token,
+                'token' => $token,
             ]);
         }
 

--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -43,7 +43,6 @@ class AdminController extends Controller
             'is_super' => 'sometimes|boolean',
         ]);
 
-        $data['api_token'] = Str::random(60);
         $data['is_super'] = $request->boolean('is_super');
         Admin::create($data);
 

--- a/app/Http/Middleware/AuthenticateApiToken.php
+++ b/app/Http/Middleware/AuthenticateApiToken.php
@@ -5,6 +5,7 @@ namespace App\Http\Middleware;
 use Closure;
 use Illuminate\Http\Request;
 use App\Models\Admin;
+use Laravel\Sanctum\PersonalAccessToken;
 
 class AuthenticateApiToken
 {
@@ -15,11 +16,12 @@ class AuthenticateApiToken
             return response()->json(['message' => 'Unauthenticated'], 401);
         }
 
-        $admin = Admin::where('api_token', $token)->first();
-        if (! $admin) {
+        $accessToken = PersonalAccessToken::findToken($token);
+        if (! $accessToken || ! $accessToken->tokenable instanceof Admin) {
             return response()->json(['message' => 'Unauthenticated'], 401);
         }
 
+        $admin = $accessToken->tokenable;
         $request->setUserResolver(fn () => $admin);
 
         return $next($request);

--- a/app/Models/Admin.php
+++ b/app/Models/Admin.php
@@ -5,24 +5,23 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Laravel\Sanctum\HasApiTokens;
 
 class Admin extends Authenticatable
 {
-    use HasFactory, Notifiable;
+    use HasApiTokens, HasFactory, Notifiable;
 
     protected $fillable = [
         'name',
         'age',
         'email',
         'password',
-        'api_token',
         'is_super',
     ];
 
     protected $hidden = [
         'password',
         'remember_token',
-        'api_token',
     ];
 
     protected function casts(): array

--- a/database/factories/AdminFactory.php
+++ b/database/factories/AdminFactory.php
@@ -4,7 +4,6 @@ namespace Database\Factories;
 
 use App\Models\Admin;
 use Illuminate\Database\Eloquent\Factories\Factory;
-use Illuminate\Support\Str;
 
 /**
  * @extends Factory<Admin>
@@ -20,7 +19,6 @@ class AdminFactory extends Factory
             'age' => $this->faker->numberBetween(20, 60),
             'email' => $this->faker->unique()->safeEmail(),
             'password' => 'password',
-            'api_token' => Str::random(60),
             'is_super' => false,
         ];
     }

--- a/database/seeders/AdminSeeder.php
+++ b/database/seeders/AdminSeeder.php
@@ -4,7 +4,6 @@ namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
 use App\Models\Admin;
-use Illuminate\Support\Str;
 
 class AdminSeeder extends Seeder
 {
@@ -46,7 +45,7 @@ class AdminSeeder extends Seeder
         foreach ($admins as $admin) {
             Admin::firstOrCreate(
                 ['email' => $admin['email']],
-                $admin + ['api_token' => Str::random(60)]
+                $admin
             );
         }
     }

--- a/database/seeders/SuperAdminSeeder.php
+++ b/database/seeders/SuperAdminSeeder.php
@@ -4,7 +4,6 @@ namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
 use App\Models\Admin;
-use Illuminate\Support\Str;
 
 class SuperAdminSeeder extends Seeder
 {
@@ -29,7 +28,6 @@ class SuperAdminSeeder extends Seeder
             Admin::firstOrCreate(
                 ['email' => $super['email']],
                 $super + [
-                    'api_token' => Str::random(60),
                     'is_super' => true,
                 ]
             );

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -32,7 +32,6 @@ class ExampleTest extends TestCase
             'age' => 30,
             'email' => 'admin@example.com',
             'password' => 'password',
-            'api_token' => 'token',
             'is_super' => true,
         ]);
         $this->actingAs($admin, 'admin');


### PR DESCRIPTION
## Summary
- switch Admin model to use Laravel Sanctum tokens
- issue Sanctum token on login and validate via middleware
- remove old api_token handling from seeds and factories

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684a491cd33c8329a40922b8e33ba3f4