### PR TITLE
Add data prefix API token auth

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -7,6 +7,18 @@ use App\Http\Controllers\AdminAuthController;
 Route::post('/login', [AdminAuthController::class, 'login'])
     ->middleware('verify.admin.credentials');
 
+Route::prefix('data')->group(function () {
+    Route::post('/api/login', [AdminAuthController::class, 'login'])
+        ->middleware('verify.admin.credentials');
+
+    Route::prefix('api')->middleware('auth.api')->group(function () {
+        Route::get('/drivers', [DriverController::class, 'index']);
+        Route::post('/drivers', [DriverController::class, 'store']);
+        Route::get('/drivers/{driver}', [DriverController::class, 'show']);
+        Route::get('/driver{driver}', [DriverController::class, 'show'])->whereNumber('driver');
+    });
+});
+
 Route::middleware('auth.api')->group(function () {
     Route::get('/drivers', [DriverController::class, 'index']);
     Route::post('/drivers', [DriverController::class, 'store']);

--- a/tests/Feature/DataApiTest.php
+++ b/tests/Feature/DataApiTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Admin;
+use App\Models\Driver;
+use Tests\TestCase;
+
+class DataApiTest extends TestCase
+{
+    public function test_driver_endpoint_requires_authentication(): void
+    {
+        Driver::factory()->create(['id' => 1]);
+
+        $response = $this->get('/data/api/driver1');
+
+        $response->assertStatus(401);
+    }
+
+    public function test_authenticated_access_to_driver_endpoint(): void
+    {
+        $admin = Admin::factory()->create(['password' => 'secret']);
+        Driver::factory()->create(['id' => 1]);
+
+        $loginResponse = $this->post('/data/api/login', [
+            'email' => $admin->email,
+            'password' => 'secret',
+        ], ['Accept' => 'application/json']);
+
+        $token = $loginResponse->json('token');
+        $this->assertNotEmpty($token);
+
+        $response = $this->get('/data/api/driver1', [
+            'Authorization' => 'Bearer ' . $token,
+        ]);
+
+        $response->assertStatus(200)
+                 ->assertJsonFragment(['id' => 1]);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add dedicated `data/api` routes that rely on bearer token auth
- test access with and without a token

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a4df0e7f88329827b3eda09bad87d