### PR TITLE
Implement JWT auth for driver API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 APP_NAME=Laravel
 APP_ENV=local
 APP_KEY=
+JWT_SECRET=your-secret-key
 APP_DEBUG=true
 APP_URL=http://localhost
 

--- a/app/Http/Controllers/api/get_userAPI.php
+++ b/app/Http/Controllers/api/get_userAPI.php
@@ -5,9 +5,20 @@ namespace App\Http\Controllers\api;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Models\Driver;
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
 
 class get_userAPI extends Controller
 {
+    /**
+     * Secret key used to sign JWT tokens.
+     */
+    private string $jwtSecret;
+
+    public function __construct()
+    {
+        $this->jwtSecret = env('JWT_SECRET', 'my-secret-key');
+    }
     /**
      * Display a listing of the resource.
      */
@@ -17,24 +28,77 @@ class get_userAPI extends Controller
     }
 
     /**
-     * Store a newly created resource in storage.
+     * Authenticate a driver and generate a JWT token.
      */
-    public function store(Request $request)
+    public function authenticate(Request $request, string $id)
     {
-        //
+        $driver = Driver::find($id);
+        if (! $driver) {
+            return response()->json(['error' => 'Driver not found'], 404);
+        }
+
+        $credentials = $request->only([
+            'full_name',
+            'phone',
+            'email',
+            'birthdate',
+            'gender',
+            'password_for_profile',
+        ]);
+
+        foreach ($credentials as $key => $value) {
+            if ($driver->{$key} != $value) {
+                return response()->json(['error' => 'Invalid credentials'], 401);
+            }
+        }
+
+        $payload = array_merge(['id' => $driver->id], $credentials);
+
+        $jwt = JWT::encode($payload, $this->jwtSecret, 'HS256');
+
+        return response()->json(['token' => $jwt]);
     }
 
     /**
      * Display the specified resource.
      */
-    public function show(string $id)
+    public function show(Request $request, string $id)
     {
+        $token = $request->bearerToken() ?? $request->query('token');
+
+        if (! $token) {
+            return response()->json(['error' => 'Token required'], 401);
+        }
+
+        try {
+            $payload = JWT::decode($token, new Key($this->jwtSecret, 'HS256'));
+        } catch (\Exception $e) {
+            return response()->json(['error' => 'Invalid token'], 401);
+        }
+
+        if ($payload->id != $id) {
+            return response()->json(['error' => 'Invalid token'], 401);
+        }
+
         $driver = Driver::find($id);
-        if ($driver) {
-            return response()->json($driver);
-        } else {
+        if (! $driver) {
             return response()->json(['error' => 'Driver not found'], 404);
         }
+
+        foreach ([
+            'full_name',
+            'phone',
+            'email',
+            'birthdate',
+            'gender',
+            'password_for_profile',
+        ] as $field) {
+            if ($driver->{$field} != ($payload->{$field} ?? null)) {
+                return response()->json(['error' => 'Invalid token'], 401);
+            }
+        }
+
+        return response()->json($driver);
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
+        "firebase/php-jwt": "^6.11",
         "illuminate/http": "*",
         "laravel/framework": "^12.0",
         "laravel/sanctum": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "33f2df4d600d2a17c0dbd40c79bb3fe9",
+    "content-hash": "01e174de0228879e79e7fa1473e3a618",
     "packages": [
         {
             "name": "brick/math",
@@ -509,6 +509,69 @@
                 }
             ],
             "time": "2025-03-06T22:45:56+00:00"
+        },
+        {
+            "name": "firebase/php-jwt",
+            "version": "v6.11.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/firebase/php-jwt.git",
+                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
+                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^7.4",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "psr/cache": "^2.0||^3.0",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0"
+            },
+            "suggest": {
+                "ext-sodium": "Support EdDSA (Ed25519) signatures",
+                "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Firebase\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Neuman Vong",
+                    "email": "neuman+pear@twilio.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Anant Narayanan",
+                    "email": "anant@php.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
+            "homepage": "https://github.com/firebase/php-jwt",
+            "keywords": [
+                "jwt",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/firebase/php-jwt/issues",
+                "source": "https://github.com/firebase/php-jwt/tree/v6.11.1"
+            },
+            "time": "2025-04-09T20:32:01+00:00"
         },
         {
             "name": "fruitcake/php-cors",
@@ -8145,12 +8208,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.2"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "plugin-api-version": "2.6.0"
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,4 +6,5 @@ use App\Http\Controllers\api\get_userAPI;
 
 Route::get('/user', [get_userAPI::class, 'index']);
 Route::get('/user/{id}', [get_userAPI::class, 'show']);
+Route::post('/user/{id}', [get_userAPI::class, 'authenticate']);
 


### PR DESCRIPTION
## Summary
- add `firebase/php-jwt` dependency
- create JWT-secured driver API
- expose POST route for JWT token generation
- document secret in `.env.example`

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_684a886240288329be3173e41054050e