### PR TITLE
Add JWT auth and token seeder

### DIFF
--- a/app/Http/Controllers/api/get_userAPI.php
+++ b/app/Http/Controllers/api/get_userAPI.php
@@ -5,6 +5,8 @@ namespace App\Http\Controllers\api;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Models\Driver;
+use Tymon\JWTAuth\Exceptions\JWTException;
+use Tymon\JWTAuth\Facades\JWTAuth;
 
 class get_userAPI extends Controller
 {
@@ -17,6 +19,12 @@ class get_userAPI extends Controller
      */
     public function index()
     {
+        try {
+            JWTAuth::parseToken()->authenticate();
+        } catch (JWTException $e) {
+            return response()->json(['error' => 'Unauthorized'], 401);
+        }
+
         return response()->json(Driver::all());
     }
 
@@ -33,12 +41,18 @@ class get_userAPI extends Controller
      */
     public function show(string $id)
     {
+        try {
+            JWTAuth::parseToken()->authenticate();
+        } catch (JWTException $e) {
+            return response()->json(['error' => 'Unauthorized'], 401);
+        }
+
         $driver = Driver::find($id);
         if ($driver) {
             return response()->json($driver);
-        } else {
-            return response()->json(['error' => 'Driver not found'], 404);
         }
+
+        return response()->json(['error' => 'Driver not found'], 404);
     }
 
     /**

--- a/database/seeders/ApiExampleSeeder.php
+++ b/database/seeders/ApiExampleSeeder.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Admin;
+use Illuminate\Support\Facades\Hash;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+class ApiExampleSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $admin = Admin::firstOrCreate(
+            ['email' => 'apiuser@example.com'],
+            [
+                'name' => 'API User',
+                'password' => Hash::make('password'),
+                'is_super' => false,
+            ]
+        );
+
+        $token = JWTAuth::fromUser($admin);
+        $admin->api_token = $token;
+        $admin->save();
+
+        $this->command->info('Example JWT Token for apiuser@example.com: ' . $token);
+    }
+}
+

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Models\User;
 use Database\Seeders\AdminSeeder;
 use Database\Seeders\SuperAdminSeeder;
+use Database\Seeders\ApiExampleSeeder;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -28,6 +29,7 @@ class DatabaseSeeder extends Seeder
         $this->call([
             AdminSeeder::class,
             SuperAdminSeeder::class,
+            ApiExampleSeeder::class,
         ]);
     }
 }


### PR DESCRIPTION
## Summary
- enforce JWT token check in `get_userAPI` controller
- provide an example JWT token via new `ApiExampleSeeder`
- include new seeder in `DatabaseSeeder`

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684a953aacbc8329967ab56729db7fd6