### PR TITLE
Implement driver rejection remarks

### DIFF
--- a/app/Http/Controllers/DriverController.php
+++ b/app/Http/Controllers/DriverController.php
@@ -169,12 +169,18 @@ class DriverController extends Controller
     {
         $driver = Driver::findOrFail($id);
 
-        $status = $request->input('status', 'Approved');
-        if (!in_array($status, ['No_approve', 'Pending', 'Approved'])) {
-            $status = 'Approved';
+        $data = $request->validate([
+            'status' => 'required|in:No_approve,Pending,Approved',
+            'remark' => 'nullable|string',
+        ]);
+
+        if ($data['status'] === 'No_approve') {
+            $request->validate(['remark' => 'required|string']);
+            $driver->remark = $data['remark'];
+            $driver->remarked_at = now();
         }
 
-        $driver->status = $status;
+        $driver->status = $data['status'];
         $driver->save();
 
         return redirect()->route('drivers.index');

--- a/app/Models/Driver.php
+++ b/app/Models/Driver.php
@@ -31,7 +31,9 @@ class Driver extends Model
         'vehicle_insurance_path',
         'service_type',
         'status',
-        'os'
+        'os',
+        'remark',
+        'remarked_at'
     ];
 
     protected $hidden = [
@@ -42,5 +44,6 @@ class Driver extends Model
     protected $casts = [
         'email_verified_at' => 'date',
         'password' => 'hashed',
+        'remarked_at' => 'datetime',
     ];
 }

--- a/database/migrations/2025_06_14_010000_add_remark_to_drivers_table.php
+++ b/database/migrations/2025_06_14_010000_add_remark_to_drivers_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('drivers', function (Blueprint $table) {
+            $table->text('remark')->nullable();
+            $table->timestamp('remarked_at')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('drivers', function (Blueprint $table) {
+            $table->dropColumn(['remark', 'remarked_at']);
+        });
+    }
+};

--- a/resources/views/drivers/index.blade.php
+++ b/resources/views/drivers/index.blade.php
@@ -45,11 +45,12 @@
                     <td>{{ $driver->updated_at->format('Y-m-d H:i:s') }}</td>
                     <td>
                         <a href="{{ route('drivers.show', $driver) }}" class="btn btn-sm btn-info">More information</a>
-                        <form action="{{ route('drivers.approve', $driver) }}" method="POST" style="display:inline;">
+                        <form action="{{ route('drivers.approve', $driver) }}" method="POST" style="display:inline;" class="reject-form">
                             @csrf
                             @method('PUT')
                             <input type="hidden" name="status" value="No_approve">
-                            <button class="btn btn-sm btn-danger">rejected</button>
+                            <input type="hidden" name="remark" value="">
+                            <button type="button" class="btn btn-sm btn-danger btn-reject">rejected</button>
                         </form>
                         <form action="{{ route('drivers.approve', $driver) }}" method="POST" style="display:inline;">
                             @csrf
@@ -74,9 +75,45 @@
 @section('script')
   <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
   <script src="https://cdn.datatables.net/2.2.2/js/dataTables.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
   <script>
     $(document).ready(function() {
-      $('#drivers-table').DataTable(); 
+      $('#drivers-table').DataTable();
+
+      $('.btn-reject').on('click', function (e) {
+        e.preventDefault();
+        const form = $(this).closest('form');
+        Swal.fire({
+          title: 'Reject driver?',
+          text: 'ต้องการกด rejected หรือไม่',
+          icon: 'warning',
+          showCancelButton: true,
+          confirmButtonText: 'Yes',
+          cancelButtonText: 'No'
+        }).then(result => {
+          if (result.isConfirmed) {
+            Swal.fire({
+              title: 'เหตุผลในการ Reject',
+              input: 'textarea',
+              inputAttributes: { required: true },
+              showCancelButton: true,
+              confirmButtonText: 'Submit',
+              cancelButtonText: 'Cancel',
+              preConfirm: value => {
+                if (!value) {
+                  Swal.showValidationMessage('กรุณากรอกเหตุผล');
+                }
+                return value;
+              }
+            }).then(res => {
+              if (res.isConfirmed) {
+                form.find('input[name="remark"]').val(res.value);
+                form.submit();
+              }
+            });
+          }
+        });
+      });
     });
   </script>
 @endsection

--- a/resources/views/drivers/show.blade.php
+++ b/resources/views/drivers/show.blade.php
@@ -5,6 +5,16 @@
     <h1 class="mt-4">Driver Details</h1>
     <a href="{{ route('drivers.index') }}" class="btn btn-secondary mb-3">Back</a>
 
+    @if($driver->remark)
+        <div class="mb-3">
+            <label class="form-label">Remark</label>
+            <textarea class="form-control" readonly>{{ $driver->remark }}</textarea>
+            @if($driver->remarked_at)
+                <small class="text-muted">{{ $driver->remarked_at->format('Y-m-d H:i:s') }}</small>
+            @endif
+        </div>
+    @endif
+
     <form action="{{ route('drivers.update', $driver) }}" method="POST" enctype="multipart/form-data">
         @csrf
         @method('PUT')


### PR DESCRIPTION
## Summary
- allow admins to add a rejection remark when changing status
- store remark and timestamp in drivers table
- display remark on driver detail view
- enhance index page with SweetAlert prompt for rejection

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_684bb24ed1d08329a1f7e2e5a88f698b